### PR TITLE
Support for client certificates.

### DIFF
--- a/intra/intra.go
+++ b/intra/intra.go
@@ -68,12 +68,13 @@ func ConnectIntraTunnel(fd int, fakedns string, dohdns doh.Transport, protector 
 // `ips` is an optional comma-separated list of IP addresses for the server.  (This
 //   wrapper is required because gomobile can't make bindings for []string.)
 // `protector` is the socket protector to use for all external network activity.
+// `loader` will provide a client certificate if required by the TLS server.
 // `listener` will be notified after each DNS query succeeds or fails.
-func NewDoHTransport(url string, ips string, protector protect.Protector, listener tunnel.IntraListener) (doh.Transport, error) {
+func NewDoHTransport(url string, ips string, protector protect.Protector, loader doh.CertificateLoader, listener tunnel.IntraListener) (doh.Transport, error) {
 	split := []string{}
 	if len(ips) > 0 {
 		split = strings.Split(ips, ",")
 	}
 	dialer := protect.MakeDialer(protector)
-	return doh.NewTransport(url, split, dialer, listener)
+	return doh.NewTransport(url, split, dialer, loader, listener)
 }

--- a/tunnel/intra/doh/client_auth.go
+++ b/tunnel/intra/doh/client_auth.go
@@ -1,0 +1,142 @@
+// Copyright 2020 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doh
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"sync"
+)
+
+// CertificateLoader interface for requesting ClientAuth instances.
+type CertificateLoader interface {
+	// Request a ClientAuth instance (blocking).
+	// returns nil (no authentication) or a ClientAuth instance.
+	LoadClientCertificate() ClientAuth
+}
+
+// ClientAuth interface for providing TLS certificates and signatures.
+type ClientAuth interface {
+	// GetClientCertificate returns the client certificate (if any).
+	// It does not block or cause certificates to load.
+	// Returns a DER encoded X.509 client certificate.
+	GetClientCertificate() []byte
+	// GetIntermediateCertificate returns the chaining certificate (if any).
+	// It does not block or cause certificates to load.
+	// Returns a DER encoded X.509 certificate.
+	GetIntermediateCertificate() []byte
+	// Request a signature on a digest.
+	Sign(digest []byte) []byte
+}
+
+// clientAuthWrapper manages certificate loading and usage during TLS handshakes.
+// Implements crypto.Signer.
+type clientAuthWrapper struct {
+	sync.Mutex
+	loadCertificateOnce sync.Once
+	loader              CertificateLoader
+
+	certificate tls.Certificate
+	signer      ClientAuth
+}
+
+func (ca *clientAuthWrapper) loadClientCertificate() {
+	// Ensure that any previous certificate is cleared regardless of success.
+	ca.certificate = tls.Certificate{}
+	// If no loader was provided then we can't load a certificate.
+	if ca.loader == nil {
+		return
+	}
+	signer := ca.loader.LoadClientCertificate()
+	if signer == nil {
+		return
+	}
+	cert := signer.GetClientCertificate()
+	if cert == nil {
+		return
+	}
+	intermediate := signer.GetIntermediateCertificate()
+	chain := make([][]byte, 0, 2)
+	chain = append(chain, cert)
+	if intermediate != nil {
+		chain = append(chain, intermediate)
+	}
+	leaf, err := x509.ParseCertificate(cert)
+	if err != nil {
+		return
+	}
+	_, isECDSA := leaf.PublicKey.(*ecdsa.PublicKey)
+	if !isECDSA {
+		// RSA-PSS and RSA-SSA both need explicit signature generation support.
+		// Fail here rather than during signing.
+		return
+	}
+	ca.certificate = tls.Certificate{
+		Certificate: chain,
+		PrivateKey:  ca,
+		Leaf:        leaf,
+	}
+	ca.signer = signer
+}
+
+func (ca *clientAuthWrapper) finalizeClientAuth() {
+	// Attempt to set signer on the first call.
+	// Subsequent callers will block until this completes,
+	// ensuring ca.signer and ca.certificate are both safe to access.
+	ca.Lock()
+	defer ca.Unlock()
+	ca.loadCertificateOnce.Do(ca.loadClientCertificate)
+}
+
+// Fetch the client certificate from the ClientAuth provider.
+// Implements tls.Config GetClientCertificate().
+func (ca *clientAuthWrapper) GetClientCertificate(
+	info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	ca.finalizeClientAuth()
+	return &ca.certificate, nil
+}
+
+// Public returns the public key for the client certificate.
+func (ca *clientAuthWrapper) Public() crypto.PublicKey {
+	ca.finalizeClientAuth()
+	cert := ca.certificate
+	if cert.Leaf == nil {
+		return nil
+	}
+	return cert.Leaf.PublicKey
+}
+
+// Sign a digest.
+func (ca *clientAuthWrapper) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	ca.finalizeClientAuth()
+	if ca.signer == nil {
+		return nil, errors.New("no client certificate")
+	}
+	signature := ca.signer.Sign(digest)
+	if signature == nil {
+		return nil, errors.New("failed to create signature")
+	}
+	return signature, nil
+}
+
+func newClientAuthWrapper(loader CertificateLoader) clientAuthWrapper {
+	return clientAuthWrapper{
+		loader: loader,
+	}
+}

--- a/tunnel/intra/doh/client_auth_test.go
+++ b/tunnel/intra/doh/client_auth_test.go
@@ -1,0 +1,396 @@
+// Copyright 2020 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doh
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+)
+
+// PEM encoded test leaf certificate with ECDSA public key.
+var ecCertificate string = `-----BEGIN CERTIFICATE-----
+MIIBpTCCAQ4CAiAAMA0GCSqGSIb3DQEBCwUAMD4xCzAJBgNVBAYTAlVTMQswCQYD
+VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzEKMAgGA1UECgwBWDAeFw0y
+MDExMDQwNTU2MTZaFw0zMDExMDIwNTU2MTZaMD4xCzAJBgNVBAYTAlVTMQswCQYD
+VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzEKMAgGA1UECgwBWDBZMBMG
+ByqGSM49AgEGCCqGSM49AwEHA0IABNFVWlOs0tnaLgiutLbPISCd5Fn9UJz6oDen
+prTOrHz11PiO/XiqwpJY8yO72QappL/7RYV+uw9hJfU+YOE3tZQwDQYJKoZIhvcN
+AQELBQADgYEAdy6CNPvIA7DrS6WrN7N4ZjHjeUtjj2w8n5abTHhvANEvIHI0DARI
+AoJJWp4Pe41mzFhROzo+U/ofC2b+ukA8sYqoio4QUxlSW3HkzUAR4HZMi8Risvo3
+OxSR9Lw/mGvZrJ8xr070EwnsD+cCZLfYQ0mSKDM9uPfI3YrgCVKyUwE=
+-----END CERTIFICATE-----`
+
+// PKCS8 encoded test ECDSA private key.
+var ecKey string = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgIlI6NB+skAYL36XP
+JvE+x5Nlbn0wvw2hlSqIqADiZhShRANCAATRVVpTrNLZ2i4IrrS2zyEgneRZ/VCc
++qA3p6a0zqx89dT4jv14qsKSWPMju9kGqaS/+0WFfrsPYSX1PmDhN7WU
+-----END PRIVATE KEY-----`
+
+// PEM encoded test leaf certificate with RSA public key.
+// Doubles as an intermediate depending on the test.
+var rsaCertificate string = `-----BEGIN CERTIFICATE-----
+MIICWDCCAcGgAwIBAgIUS36guwZMKNO0ADReGLi0cZq8fOowDQYJKoZIhvcNAQEL
+BQAwPjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1Nb3VudGFp
+biBWaWV3MQowCAYDVQQKDAFYMB4XDTIwMTEwNDA1NDgyNVoXDTMwMTEwMjA1NDgy
+NVowPjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1Nb3VudGFp
+biBWaWV3MQowCAYDVQQKDAFYMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDd
+eznqVu1Rn0m8KR4mX/qVv6uytzZ+juqW5VD55D+w9N6JryPpFHPi4VIm8PKLXp3X
+GvY9mc8r+0Ow1qJZYoc/X0Na1c79bv9xwbD3aK28FlAs1+cmyesaFhCWa0bYAvcy
+mqQGYhObEWb46E5AANV82CitDE9C1aXRT4SvkLnc6wIDAQABo1MwUTAdBgNVHQ4E
+FgQUnUib8BhOHqjq9+gqPQ+ePyEW9zwwHwYDVR0jBBgwFoAUnUib8BhOHqjq9+gq
+PQ+ePyEW9zwwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOBgQAx/uZG
+Gmb5w/u4UkdH7wnoOUNx6GwdraqtQWnFaXb87PmuVAjBwSAnzes2mlp/Vbcd6tYs
+pPuHrxOcWgw/aRV6rK3vJZIH3DGvy1pNphGgegEcG88nrUCDcQqPLxvPJ8bmbaee
+Tf+l5U2OHC3Yifb4FDOv47kGmq5VeWiYdp60/A==
+-----END CERTIFICATE-----`
+
+// PKCS8 encoded test RSA private key.
+var rsaKey string = `-----BEGIN PRIVATE KEY-----
+MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAN17OepW7VGfSbwp
+HiZf+pW/q7K3Nn6O6pblUPnkP7D03omvI+kUc+LhUibw8otendca9j2Zzyv7Q7DW
+ollihz9fQ1rVzv1u/3HBsPdorbwWUCzX5ybJ6xoWEJZrRtgC9zKapAZiE5sRZvjo
+TkAA1XzYKK0MT0LVpdFPhK+QudzrAgMBAAECgYEAoCdhI8Ej7qe+S993u8wfiXWG
+FL9DGpUBsYe03F5eZ/lJikopL3voqKDCJQKKgJk0jb0jXjwAgQ86TX+G+hezL5jp
+xOOfMmTYgMwnUuFYN1gHAd+TnYB9G1qSQr9TOw3K9Rf4q2x09GhLP75qdr+qzmIR
+YGle5ZSP0LqKNkpGNUECQQD+6CxOO8+knnzIFvqkUyNDVFR5ALRNpb53TGVITNf3
+ysT32oJ75ButA0l4q/jsL+MeLLvrHkJOHN+ydLaZOUkbAkEA3m5cICisW9lsT+Rj
+glXykkbj3Ougldy7rhPivAaS7clk8cl8cDcIvHna1mDlhSanUu/s4TFEXBLnSzee
+XLNIcQJBAJ0n3TD6lSEkCUB/UlX/X81B77aOZZs9pXj9o6/4mGoQHHHGyQ3C7AE1
+9pUsSZKsT3UqFU124WAxUwU+CdnbxKMCQB/QrUC0UKL6oHF0+37DCGU/2ovY8Ck/
+X2Dw2zeFwTJd4iBrb28lkAxVaaXMSkgXVUuZoco8H8kDsy2hEPe1dSECQQCPw5Yg
+2gdmdpUk+QetqqhSuuIDwILHU9m3CoX3rY+njaR5LOWDz3utC9Ogo+4wdIMamP/o
+2SAWPAZPqDUbtqGH
+-----END PRIVATE KEY-----`
+
+// fakeClientAuth implements the ClientAuth interface for testing.
+type fakeClientAuth struct {
+	ClientAuth
+
+	certificate  *x509.Certificate
+	intermediate *x509.Certificate
+	key          crypto.PrivateKey
+}
+
+func (ca *fakeClientAuth) GetClientCertificate() []byte {
+	if ca.certificate == nil {
+		// Interface uses nil for errors to support binding.
+		return nil
+	}
+	return ca.certificate.Raw
+}
+
+func (ca *fakeClientAuth) GetIntermediateCertificate() []byte {
+	if ca.intermediate == nil {
+		return nil
+	}
+	return ca.intermediate.Raw
+}
+
+func (ca *fakeClientAuth) Sign(digest []byte) []byte {
+	if ca.key == nil {
+		return nil
+	}
+	if k, isECDSA := ca.key.(*ecdsa.PrivateKey); isECDSA {
+		// We have to ASN.1 encode the signature ourselves since
+		// Go < 1.15 does not include ecdsa.SignASN1
+		// (https://github.com/golang/go/issues/20544).
+		r, s, err := ecdsa.Sign(rand.Reader, k, digest)
+		if err != nil {
+			return nil
+		}
+
+		var b cryptobyte.Builder
+		b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			b.AddASN1BigInt(r)
+			b.AddASN1BigInt(s)
+		})
+		signature, err := b.Bytes()
+		if err != nil {
+			return nil
+		}
+		return signature
+	}
+	// Unsupported key type
+	return nil
+}
+
+func newFakeClientAuth(certificate, intermediate, key []byte) (*fakeClientAuth, error) {
+	ca := &fakeClientAuth{}
+	if certificate != nil {
+		certX509, err := x509.ParseCertificate(certificate)
+		if err != nil {
+			return nil, fmt.Errorf("certificate: %v", err)
+		}
+		ca.certificate = certX509
+	}
+	if intermediate != nil {
+		intX509, err := x509.ParseCertificate(intermediate)
+		if err != nil {
+			return nil, fmt.Errorf("intermediate: %v", err)
+		}
+		ca.intermediate = intX509
+	}
+	if key != nil {
+		key, err := x509.ParsePKCS8PrivateKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("private key: %v", err)
+		}
+		ca.key = key
+	}
+	return ca, nil
+}
+
+// fakeLoader implements the CertificateLoader interface for testing.
+type fakeLoader struct {
+	CertificateLoader
+	ca ClientAuth
+}
+
+func (l *fakeLoader) LoadClientCertificate() ClientAuth {
+	return l.ca
+}
+
+func newFakeLoader(ca *fakeClientAuth) *fakeLoader {
+	return &fakeLoader{ca: ca}
+}
+
+func newCertificateRequestInfo() *tls.CertificateRequestInfo {
+	return &tls.CertificateRequestInfo{
+		Version: tls.VersionTLS13,
+	}
+}
+
+func newToBeSigned(message []byte) ([]byte, crypto.SignerOpts) {
+	digest := sha256.Sum256(message)
+	opts := crypto.SignerOpts(crypto.SHA256)
+	return digest[:], opts
+}
+
+// VerifyASN1 handles ECDSA ASN.1 signatures for Go < 1.15 support.
+// (https://github.com/golang/go/issues/20544).
+func VerifyASN1(pub *ecdsa.PublicKey, digest, signature []byte) bool {
+	var (
+		r, s  = &big.Int{}, &big.Int{}
+		inner cryptobyte.String
+	)
+	if pub == nil {
+		return false
+	}
+	input := cryptobyte.String(signature)
+	if !input.ReadASN1(&inner, asn1.SEQUENCE) ||
+		!input.Empty() ||
+		!inner.ReadASN1Integer(r) ||
+		!inner.ReadASN1Integer(s) ||
+		!inner.Empty() {
+		return false
+	}
+	return ecdsa.Verify(pub, digest, r, s)
+}
+
+// Simulate a TLS handshake that requires a client cert and signature.
+func TestSign(t *testing.T) {
+	certDer, _ := pem.Decode([]byte(ecCertificate))
+	keyDer, _ := pem.Decode([]byte(ecKey))
+	intDer, _ := pem.Decode([]byte(rsaCertificate))
+	ca, err := newFakeClientAuth(certDer.Bytes, intDer.Bytes, keyDer.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loader := newFakeLoader(ca)
+
+	wrapper := newClientAuthWrapper(loader)
+	// TLS stack requests the client cert.
+	req := newCertificateRequestInfo()
+	cert, err := wrapper.GetClientCertificate(req)
+	if err != nil {
+		t.Fatal("Expected to get a client certificate")
+	}
+	if cert == nil {
+		// From the crypto.tls docs:
+		// If GetClientCertificate returns an error, the handshake will
+		// be aborted and that error will be returned. Otherwise
+		// GetClientCertificate must return a non-nil Certificate.
+		t.Error("GetClientCertificate must return a non-nil certificate")
+	}
+	if len(cert.Certificate) != 2 {
+		t.Fatal("Certificate chain is the wrong length")
+	}
+	if !bytes.Equal(cert.Certificate[0], certDer.Bytes) {
+		t.Error("Problem with certificate chain[0]")
+	}
+	if !bytes.Equal(cert.Certificate[1], intDer.Bytes) {
+		t.Error("Problem with certificate chain[1]")
+	}
+	// TLS stack requests a signature.
+	digest, opts := newToBeSigned([]byte("hello world"))
+	signature, err := wrapper.Sign(rand.Reader, digest, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify the signature.
+	pub, ok := wrapper.Public().(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("Expected public key to be ECDSA")
+	}
+	if !VerifyASN1(pub, digest, signature) {
+		t.Fatal("Problem verifying signature")
+	}
+}
+
+// Simulate a client that does not use an intermediate certificate.
+func TestSignNoIntermediate(t *testing.T) {
+	certDer, _ := pem.Decode([]byte(ecCertificate))
+	keyDer, _ := pem.Decode([]byte(ecKey))
+	ca, err := newFakeClientAuth(certDer.Bytes, nil, keyDer.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loader := newFakeLoader(ca)
+
+	wrapper := newClientAuthWrapper(loader)
+	// TLS stack requests a client cert.
+	req := newCertificateRequestInfo()
+	cert, err := wrapper.GetClientCertificate(req)
+	if err != nil {
+		t.Error("Expected to get a client certificate")
+	}
+	if cert == nil {
+		t.Error("GetClientCertificate must return a non-nil certificate")
+	}
+	if len(cert.Certificate) != 1 {
+		t.Error("Certificate chain is the wrong length")
+	}
+	if !bytes.Equal(cert.Certificate[0], certDer.Bytes) {
+		t.Error("Problem with certificate chain[0]")
+	}
+	// TLS stack requests a signature
+	digest, opts := newToBeSigned([]byte("hello world"))
+	signature, err := wrapper.Sign(rand.Reader, digest, opts)
+	if err != nil {
+		t.Error(err)
+	}
+	// Verify the signature.
+	pub, ok := wrapper.Public().(*ecdsa.PublicKey)
+	if !ok {
+		t.Error("Expected public key to be ECDSA")
+	}
+	if !VerifyASN1(pub, digest, signature) {
+		t.Error("Problem verifying signature")
+	}
+}
+
+// Simulate a client that does not have a certificate.
+func TestNoAuth(t *testing.T) {
+	ca, err := newFakeClientAuth(nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loader := newFakeLoader(ca)
+
+	wrapper := newClientAuthWrapper(loader)
+	// TLS stack requests a client cert.
+	req := newCertificateRequestInfo()
+	cert, err := wrapper.GetClientCertificate(req)
+	if err != nil {
+		t.Error("Expected to get a client certificate")
+	}
+	if cert == nil {
+		t.Error("GetClientCertificate must return a non-nil certificate")
+	}
+	if len(cert.Certificate) != 0 {
+		t.Error("Certificate chain is the wrong length")
+	}
+	// TLS stack requests a signature. This should not happen in real life
+	// because cert.Certificate is empty.
+	digest, opts := newToBeSigned([]byte("hello world"))
+	_, err = wrapper.Sign(rand.Reader, digest, opts)
+	if err == nil {
+		t.Error("Expected Sign() to fail")
+	}
+}
+
+// Simulate a client that has an RSA certificate.
+func TestRSACertificate(t *testing.T) {
+	certDer, _ := pem.Decode([]byte(rsaCertificate))
+	keyDer, _ := pem.Decode([]byte(rsaKey))
+	ca, err := newFakeClientAuth(certDer.Bytes, nil, keyDer.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loader := newFakeLoader(ca)
+
+	wrapper := newClientAuthWrapper(loader)
+	// TLS stack requests a client cert.  We should not return one because
+	// we don't support RSA.
+	req := newCertificateRequestInfo()
+	cert, err := wrapper.GetClientCertificate(req)
+	if err != nil {
+		t.Error("Expected to get a client certificate")
+	}
+	if cert == nil {
+		t.Error("GetClientCertificate must return a non-nil certificate")
+	}
+	if len(cert.Certificate) != 0 {
+		t.Error("Unexpectedly loaded an RSA certificate")
+	}
+	// TLS stack requests a signature. This should not happen in real life
+	// because cert.Certificate is empty.
+	digest, opts := newToBeSigned([]byte("hello world"))
+	_, err = wrapper.Sign(rand.Reader, digest, opts)
+	if err == nil {
+		t.Error("Expected Sign() to fail")
+	}
+}
+
+// Simulate a nil loader.
+func TestNilLoader(t *testing.T) {
+	wrapper := newClientAuthWrapper(nil)
+	// TLS stack requests the client cert.
+	req := newCertificateRequestInfo()
+	cert, err := wrapper.GetClientCertificate(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cert == nil {
+		// From the crypto.tls docs:
+		// If GetClientCertificate returns an error, the handshake will
+		// be aborted and that error will be returned. Otherwise
+		// GetClientCertificate must return a non-nil Certificate.
+		t.Error("GetClientCertificate must return a non-nil certificate")
+	}
+	if len(cert.Certificate) != 0 {
+		t.Fatal("Expected an empty certificate chain")
+	}
+	// TLS stack requests a signature. This should not happen in real life
+	// because cert.Certificate is empty.
+	digest, opts := newToBeSigned([]byte("hello world"))
+	_, err = wrapper.Sign(rand.Reader, digest, opts)
+	if err == nil {
+		t.Error("Expected Sign() to fail")
+	}
+}

--- a/tunnel/intra/doh/doh_test.go
+++ b/tunnel/intra/doh/doh_test.go
@@ -128,7 +128,7 @@ func init() {
 
 // Check that the constructor works.
 func TestNewTransport(t *testing.T) {
-	_, err := NewTransport(testURL, ips, nil, nil)
+	_, err := NewTransport(testURL, ips, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,11 +136,11 @@ func TestNewTransport(t *testing.T) {
 
 // Check that the constructor rejects unsupported URLs.
 func TestBadUrl(t *testing.T) {
-	_, err := NewTransport("ftp://www.example.com", nil, nil, nil)
+	_, err := NewTransport("ftp://www.example.com", nil, nil, nil, nil)
 	if err == nil {
 		t.Error("Expected error")
 	}
-	_, err = NewTransport("https://www.example", nil, nil, nil)
+	_, err = NewTransport("https://www.example", nil, nil, nil, nil)
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -149,7 +149,7 @@ func TestBadUrl(t *testing.T) {
 // Check for failure when the query is too short to be valid.
 func TestShortQuery(t *testing.T) {
 	var qerr *queryError
-	doh, _ := NewTransport(testURL, ips, nil, nil)
+	doh, _ := NewTransport(testURL, ips, nil, nil, nil)
 	_, err := doh.Query([]byte{})
 	if err == nil {
 		t.Error("Empty query should fail")
@@ -188,7 +188,7 @@ func TestQueryIntegration(t *testing.T) {
 
 	testQuery := func(queryData []byte) {
 
-		doh, err := NewTransport(testURL, ips, nil, nil)
+		doh, err := NewTransport(testURL, ips, nil, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -238,7 +238,7 @@ func (r *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 
 // Check that a DNS query is converted correctly into an HTTP query.
 func TestRequest(t *testing.T) {
-	doh, _ := NewTransport(testURL, ips, nil, nil)
+	doh, _ := NewTransport(testURL, ips, nil, nil, nil)
 	transport := doh.(*transport)
 	rt := makeTestRoundTripper()
 	transport.client.Transport = rt
@@ -287,7 +287,7 @@ func queriesMostlyEqual(m1 dnsmessage.Message, m2 dnsmessage.Message) bool {
 
 // Check that a DOH response is returned correctly.
 func TestResponse(t *testing.T) {
-	doh, _ := NewTransport(testURL, ips, nil, nil)
+	doh, _ := NewTransport(testURL, ips, nil, nil, nil)
 	transport := doh.(*transport)
 	rt := makeTestRoundTripper()
 	transport.client.Transport = rt
@@ -326,7 +326,7 @@ func TestResponse(t *testing.T) {
 // Simulate an empty response.  (This is not a compliant server
 // behavior.)
 func TestEmptyResponse(t *testing.T) {
-	doh, _ := NewTransport(testURL, ips, nil, nil)
+	doh, _ := NewTransport(testURL, ips, nil, nil, nil)
 	transport := doh.(*transport)
 	rt := makeTestRoundTripper()
 	transport.client.Transport = rt
@@ -357,7 +357,7 @@ func TestEmptyResponse(t *testing.T) {
 
 // Simulate a non-200 HTTP response code.
 func TestHTTPError(t *testing.T) {
-	doh, _ := NewTransport(testURL, ips, nil, nil)
+	doh, _ := NewTransport(testURL, ips, nil, nil, nil)
 	transport := doh.(*transport)
 	rt := makeTestRoundTripper()
 	transport.client.Transport = rt
@@ -387,7 +387,7 @@ func TestHTTPError(t *testing.T) {
 
 // Simulate an HTTP query error.
 func TestSendFailed(t *testing.T) {
-	doh, _ := NewTransport(testURL, ips, nil, nil)
+	doh, _ := NewTransport(testURL, ips, nil, nil, nil)
 	transport := doh.(*transport)
 	rt := makeTestRoundTripper()
 	transport.client.Transport = rt
@@ -431,7 +431,7 @@ func (c *fakeConn) RemoteAddr() net.Addr {
 // Check that the DNSListener is called with a correct summary.
 func TestListener(t *testing.T) {
 	listener := &fakeListener{}
-	doh, _ := NewTransport(testURL, ips, nil, listener)
+	doh, _ := NewTransport(testURL, ips, nil, nil, listener)
 	transport := doh.(*transport)
 	rt := makeTestRoundTripper()
 	transport.client.Transport = rt


### PR DESCRIPTION
Support caller supplied client certificates for authentication to private/corporate DNS services.

If the caller supports client certificates (ie. supplies a non-nil CertificateLoader) then the certificate loader will be used to request a client certificate (if required) during the TLS handshake.  The CertificateLoader can then return nil or a ClientAuth instance for providing certificates and performing signing.

It is envisioned that the CertificateLoader and ClientAuth instances will be implemented in Java (eg. within Intra), and may not have direct access to the private key (eg. Android), which explains some interface choices.